### PR TITLE
Add babel-cli package locally so npm start works ootb

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "fixed-data-table": "^0.6.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.4.0",
     "babel-core": "^6.3.26",
     "babel-eslint": "^5.0.0-beta6",
     "babel-loader": "^6.2.0",


### PR DESCRIPTION
This starter kit assumes that you have globally installed the `babel-cli` package 

If you do not have this, you will get an error when running `npm start`:
`babel-node is not recognized as an internal or external command`

So I think it's better to include this as a dev dependancy (it's also recommended according https://babeljs.io/docs/usage/cli/#installation)
